### PR TITLE
Changed version to allow 0.14 as well. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.9",
   "description": "Simple iOS inspired toggle switch",
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": ">=0.13.3"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Currently would only allow react 0.13.x, where x >= 3.
Could also use "^0.13.3 || ^0.14.0" 

See https://github.com/npm/node-semver#caret-ranges-123-025-004